### PR TITLE
First version of data_loader package.

### DIFF
--- a/data_loader/__init__.py
+++ b/data_loader/__init__.py
@@ -1,0 +1,2 @@
+from data_loader.data_loader import DataLoader
+

--- a/data_loader/data_loader.py
+++ b/data_loader/data_loader.py
@@ -1,0 +1,64 @@
+import os 
+import json
+import pandas as pd
+from data_loader.dataset import IMDBDataset, LingspamDataset, News20Dataset, ReutersDataset
+
+
+class DataLoader:
+    """A composition class for datasets that allows to load them into memory.
+
+    Attributes:
+        _data_path (str): path to directory containing all datasets.
+        _datasets (dict): map between dataset names and data_loader.dataset.Dataset objects.        
+
+    """
+
+    # Set default data directory path.
+    _package_absolute_path = os.path.abspath(os.path.dirname(__file__))
+    _default_data_dir = os.path.join(_package_absolute_path, '../data/')
+
+
+    def __init__(self, data_path=_default_data_dir): 
+        self._data_path = data_path
+        self._datasets = {}
+
+        imdb_dataset_path = os.path.join(data_path, 'imdb_reviews', 'aclImdb')
+        lingspam_dataset_path = os.path.join(data_path, 'lingspam_public', 'bare')        
+        news20_dataset_path = os.path.join(data_path, 'news20', '20_newsgroup')
+        reuters_dataset_path = os.path.join(data_path, 'reuters21578')
+
+        self._datasets['imdb_reviews'] = IMDBDataset(imdb_dataset_path)
+        self._datasets['lingspam_public'] = LingspamDataset(lingspam_dataset_path)
+        self._datasets['news20'] = News20Dataset(news20_dataset_path) 
+        self._datasets['reuters21578'] = ReutersDataset(reuters_dataset_path)        
+
+
+    def load_dataset(self, settings):
+        """Returns  given dataset split between training and test set.
+        
+        Args:
+            settings (file object): experiment description in JSON format 
+        Returns:
+            train_set (pd.DataFrame): dataframe containing individual labeled documents from dataset 
+            test_set (pd.DataFrame): as above
+        
+        Example:
+            >>> from data_loader import DataLoader
+            >>> loader = DataLoader()
+            >>> with open('experiment_1.txt', 'r') as settings:
+            ...     train_set, test_set = loader.load_dataset(settings)        
+
+        """ 
+        
+        settings = json.load(settings)
+        dataset_name = settings['dataset']
+
+        if dataset_name in self._datasets.keys():
+            return self._datasets[dataset_name].get_dataset()
+        else:
+            dataset_names = self._datasets.keys()
+            dataset_names = ['\'' + name + '\'' for name in dataset_names]
+            err_msg = 'Dataset \'{}\' could not be found. Available datasets:\n'.format(dataset_name) 
+            err_msg += '\n'.join(dataset_names)
+            raise NameError(err_msg)
+

--- a/data_loader/dataset/__init__.py
+++ b/data_loader/dataset/__init__.py
@@ -1,0 +1,5 @@
+from data_loader.dataset.imdb_dataset import IMDBFileUtil, IMDBDataset
+from data_loader.dataset.lingspam_dataset import LingFileUtil, LingspamDataset
+from data_loader.dataset.news20_dataset import News20FileUtil, News20Dataset
+from data_loader.dataset.reuters_dataset import ReutersFileUtil, ReutersDataset
+ 

--- a/data_loader/dataset/dataset.py
+++ b/data_loader/dataset/dataset.py
@@ -1,0 +1,65 @@
+import pandas as pd 
+import multiprocessing as mp 
+from data_loader.file_util import FileUtil
+
+
+class Dataset:
+    """A base class for dataset access endpoint objects.
+
+    Attributes:
+        _data_path (str): path to the directory containing dataset files.
+        _file_util (data_loader.file_util.FileUtil): utility object dealing with loading files.
+    
+    """
+
+    
+    def __init__(self, data_path):
+        self._data_path = data_path
+        self._file_util = FileUtil()
+
+     
+    def _build_dataframe(self, file_paths, workers=mp.cpu_count()):
+        """Builds appropriate dataframe from all given data files.
+
+        Args:
+            file_paths (list(str)): paths to all data files we want to wrap as a dataframe.
+            workers (int): number of processes to be spawned to build the dataframe.            
+        Returns:
+            dataframe (pandas.DataFrame): the resulting dataframe.            
+
+        """
+        
+        try:
+            chunksize = int(len(file_paths) / workers)
+            pool = mp.Pool(processes=workers)              
+            results = pool.map(self._file_util.load_single_file, file_paths, chunksize)
+            pool.close()
+            pool.join()
+        except NotImplementedError:
+            raise NotImplementedError('Cannot call this method on base class instance!')
+        
+        # Flatten resulting lists if necessary.
+        contents = [res[0] if isinstance(res[0], list) else [res[0]] for res in results] 
+        contents = [el for sub_list in contents for el in sub_list]
+        
+        labels = [res[1] if isinstance(res[1], list) else [res[1]] for res in results]       
+        labels = [el for sub_list in labels for el in sub_list]
+        
+        data_dict = {}
+        data_dict['document'] = contents     
+        data_dict['label'] = labels
+
+        return pd.DataFrame.from_dict(data_dict)
+
+
+    def get_dataset(self):
+        """Returns particular dataset.
+       
+        Returns:
+            train_set (pandas.DataFrame): training set dataframe.
+            test_set (pandas.DataFrame): test set dataframe.
+
+        """                
+        
+        raise NotImplementedError('Cannot call this method on base class instance!')
+

--- a/data_loader/dataset/imdb_dataset.py
+++ b/data_loader/dataset/imdb_dataset.py
@@ -1,0 +1,68 @@
+import os
+import pandas as pd
+import multiprocessing as mp 
+from data_loader.dataset.dataset import Dataset
+from data_loader.file_util import FileUtil
+
+
+class IMDBFileUtil(FileUtil):
+    """Utility class for accessing files in IMDB movie reviews dataset."""    
+
+
+    @staticmethod
+    def load_single_file(path):
+        """Loads a single file from IMDB dataset.
+        
+        Args:
+            path (str): path to the file to be loaded.       
+        Returns:
+            content (str): content of the document.
+            label (int): label of the document.
+ 
+        """
+
+        name = os.path.basename(path)
+        
+        number, rating = name.split('_')
+        label = int(rating[:-4])
+               
+        with open(path, 'r') as doc_file:
+            content = doc_file.read()
+
+        return content, label 
+
+
+class IMDBDataset(Dataset):
+    """A wrapper class for IMDB movie reviews dataset."""
+
+
+    def __init__(self, data_path):
+        super(IMDBDataset, self).__init__(data_path)
+        self._file_util = IMDBFileUtil()
+
+        
+    def get_dataset(self):
+        """Returns IMDB movie reviews dataset.
+       
+        Returns:
+            train_set (pandas.DataFrame): training set dataframe.
+            test_set (pandas.DataFrame): test set dataframe.
+
+        """                
+        
+        # Get lists of file paths for training and test sets, respectively.
+        files_lists = []
+        for dir_1 in ['train', 'test']:
+            for dir_2 in ['pos', 'neg']:
+                dir_path = os.path.join(self._data_path, dir_1, dir_2) 
+                files_lists.append(self._file_util.get_files(dir_path))
+
+        train_set_paths = files_lists[0] + files_lists[1]
+        test_set_paths = files_lists[2] + files_lists[3] 
+                 
+        # Build appropriate dataframes. 
+        train_set = self._build_dataframe(train_set_paths)
+        test_set = self._build_dataframe(test_set_paths) 
+
+        return train_set, test_set            
+

--- a/data_loader/dataset/lingspam_dataset.py
+++ b/data_loader/dataset/lingspam_dataset.py
@@ -1,0 +1,74 @@
+import os
+import pandas as pd
+import multiprocessing as mp
+from data_loader.dataset.dataset import Dataset
+from data_loader.file_util import FileUtil
+
+
+class LingFileUtil(FileUtil):
+    """Utility class for accessing files in Ling-Spam dataset."""    
+    
+
+    @staticmethod
+    def load_single_file(path):
+        """Loads a single file from Ling-Spam dataset.
+        
+        The file is added to docs_list as an appropriate tuple (described below).
+
+        Args:
+            path (str): path to the file to be loaded.       
+        Returns:
+            content (str): content of the document.
+            label (int): label of the document.
+ 
+        """
+    
+        name = os.path.basename(path)
+        
+        if 'spmsg' in name:
+            label = 1
+        else:
+            label = 0
+ 
+        with open(path, 'r') as doc_file:
+            content = doc_file.read()
+        
+        return content, label
+
+
+class LingspamDataset(Dataset):
+    """A wrapper class for Ling-Spam dataset."""
+    
+
+    def __init__(self, data_path):
+        super(LingspamDataset, self).__init__(data_path)
+        self._file_util = LingFileUtil()
+
+    
+    def get_dataset(self):
+        """Returns Ling-Spam dataset.
+       
+        Returns:
+            train_set (pandas.DataFrame): training set dataframe.
+            test_set (pandas.DataFrame): test set dataframe.
+
+        """                
+
+        # Get lists of file paths for training and test sets, respectively.
+        files_list = []
+        for i in range(1, 11):
+            dir_path = os.path.join(self._data_path, 'part%d' % i)            
+            files_list.extend(self._file_util.get_files(dir_path))
+
+        train_test_ratio = 0.5
+        breakpoint = int(train_test_ratio * len(files_list))
+        
+        train_set_paths = files_list[:breakpoint]
+        test_set_paths = files_list[breakpoint:]
+        
+        # Build appropriate dataframes. 
+        train_set = self._build_dataframe(train_set_paths)
+        test_set = self._build_dataframe(test_set_paths) 
+        
+        return train_set, test_set            
+ 

--- a/data_loader/dataset/news20_dataset.py
+++ b/data_loader/dataset/news20_dataset.py
@@ -1,0 +1,66 @@
+import os
+import pandas as pd
+from data_loader.dataset.dataset import Dataset
+from data_loader.file_util import FileUtil
+
+
+class News20FileUtil(FileUtil):
+    """Utility class for accessing files in IMDB movie reviews dataset."""    
+
+
+    @staticmethod
+    def load_single_file(path):
+        """Loads a single file from 20 Newsgroup dataset.
+
+        Args:
+            path (str): path to the file to be loaded. 
+        Returns:
+            content (str): content(s) of the document.
+            label (str): label (topic) of the document.
+ 
+        """
+
+        label = os.path.basename(os.path.dirname(path))     
+         
+        with open(path, 'r', encoding='utf8', errors='ignore') as doc_file:
+            content = doc_file.read()            
+            content = content.split('\n\n', maxsplit=1)[1]
+        return content, label
+
+
+class News20Dataset(Dataset):
+    """A wrapper class for 20 Newsgroup dataset."""
+
+
+    def __init__(self, data_path):
+        super(News20Dataset, self).__init__(data_path)
+        self._file_util = News20FileUtil()
+
+    
+    def get_dataset(self):
+        """Returns 20 Newsgroup dataset.
+       
+        Returns:
+            train_set (pandas.DataFrame): training set dataframe.
+            test_set (pandas.DataFrame): test set dataframe.
+
+        """                
+        
+        files_list = []        
+        for directory in os.scandir(self._data_path):
+            files_list.extend(self._file_util.get_files(directory.path))
+
+        train_test_ratio = 0.5
+        breakpoint = int(train_test_ratio * len(files_list))
+        
+        train_set_paths = files_list[:breakpoint]
+        test_set_paths = files_list[breakpoint:]
+
+        assert train_set_paths and test_set_paths
+        
+        # Build appropriate dataframes. 
+        train_set = self._build_dataframe(train_set_paths)
+        test_set = self._build_dataframe(test_set_paths) 
+
+        return train_set, test_set            
+

--- a/data_loader/dataset/reuters_dataset.py
+++ b/data_loader/dataset/reuters_dataset.py
@@ -1,0 +1,80 @@
+import os
+import pandas as pd
+import multiprocessing as mp
+from bs4 import BeautifulSoup as BS
+from data_loader.dataset.dataset import Dataset
+from data_loader.file_util import FileUtil
+
+
+class ReutersFileUtil(FileUtil):
+    """Utility class for accessing files in Reuters-21578 dataset."""    
+
+
+    @staticmethod
+    def load_single_file(path):
+        """Loads a single file from Reuters dataset.
+        
+        Args:
+            path (str): path to the file to be loaded.    
+        Returns:
+            content (list(str)): contents of documents (there are multiple ones in a single file).
+            label (list(str)): labels of documents.
+ 
+        """
+        
+        with open(path, 'r', encoding='utf8', errors='ignore') as doc_file:
+            file_content = doc_file.read()
+       
+            # That's necessary for BeautifulSoup to parse the file.
+            file_content = file_content.replace('<BODY>', '<CONTENT>').replace('</BODY>', '</CONTENT>')
+             
+        soup = BS(file_content, 'lxml')
+        
+        articles = soup.find_all('reuters')
+        
+        # Find all articles that have non empty content and some topic.
+        valid_articles = []    
+        
+        for art in articles:
+            if art.content and art.content.text and art.topics.text:
+                valid_articles.append(art)
+
+        content = [art.content.text for art in valid_articles]
+        label = [art.topics.text for art in valid_articles]
+
+        return content, label  
+
+
+class ReutersDataset(Dataset):
+    """A wrapper class for Reuters-21578 dataset."""
+
+
+    def __init__(self, data_path):
+        super(ReutersDataset, self).__init__(data_path)
+        self._file_util = ReutersFileUtil()
+
+    
+    def get_dataset(self):
+        """Returns Reuters dataset.
+       
+        Returns:
+            train_set (pandas.DataFrame): training set dataframe.
+            test_set (pandas.DataFrame): test set dataframe.
+
+        """                
+        
+        files_list = self._file_util.get_files(self._data_path)
+        files_list = [path for path in files_list if os.path.basename(path).startswith('reut')]                  
+        
+        train_test_ratio = 0.5
+        breakpoint = int(train_test_ratio * len(files_list))
+        
+        train_set_paths = files_list[:breakpoint]
+        test_set_paths = files_list[breakpoint:]
+        
+        # Build appropriate dataframes. 
+        train_set = self._build_dataframe(train_set_paths)
+        test_set = self._build_dataframe(test_set_paths) 
+
+        return train_set, test_set            
+ 

--- a/data_loader/file_util.py
+++ b/data_loader/file_util.py
@@ -1,0 +1,45 @@
+import os
+import pandas as pd
+
+
+class FileUtil:
+    """Utility base class for accessing files in some dataset (specified via inheritance)."""    
+
+
+    @staticmethod
+    def get_files(dir_path):
+        """Returns all data file paths from given directory.
+
+        Args:
+            dir_path (str): the directory we want files from. 
+        Returns:
+            file_paths (list(str)): paths to data files in given directory.   
+
+        """ 
+        
+        file_paths = []
+
+        for entry in os.scandir(dir_path):
+            if entry.is_file():
+                file_paths.append(entry.path)
+
+        return file_paths
+
+
+    @staticmethod
+    def load_single_file(path):
+        """Loads a single file from a dataset.
+        
+        This method is implemented differently depending on the dataset it is intended to use on. 
+        The file is returned as an appropriate tuple (described below).
+
+        Args:
+            path (str): path to the file to be loaded.
+        Returns:
+            content (list(str)/str): content(s) of document(s) (depending on whether single file contains just one document or not).
+            label (list(str)/str): label(s) of document(s).
+ 
+        """
+
+        raise NotImplementedError('method load_single_file must be implemented')
+

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,6 @@
+name: doc2vec_env
+dependencies:
+    - pandas
+    - lxml
+    - beautifulsoup4
+


### PR DESCRIPTION
This is the basic version of ``data_loader`` package.  At the moment 4 datasets can be handled: _IMDB movie reviews dataset, Lingspam public dataset, 20 newsgroup dataset and Reuters-21578 dataset._ 

Obviously, you must provide the data yourself. See ``data_loader.data_loader.py`` for usage example and the default path where ``data_loader.DataLoader`` object looks for data. You can pass alternate location as an argument to ``DataLoader``'s ``__init__`` method. 

**Environment preparation tip**: cd to directory containing ``environment.yml`` file. Then do ``conda env create -f environment.yml`` to create doc2vec_env conda environment. It will already have the packages necessary to import ``data_loader`` package installed (BeautifulSoup is only necessary for Reuters dataset).